### PR TITLE
refactor(encode): make it faster from O(n²) to O(n)

### DIFF
--- a/encode.ts
+++ b/encode.ts
@@ -48,13 +48,15 @@ export function uuid58EncodeSafe(uuid: string): string | Uuid58EncodeError {
     );
   }
 
-  let encoded = "";
-  do {
-    encoded = BASE58_ALPHABET[Number(num % ALPHABET_LENGTH)] + encoded;
-    num /= ALPHABET_LENGTH;
-  } while (num > 0n);
+  const out = new Array<string>(22).fill(BASE58_ALPHABET[0]!);
+  let i = 21;
+  while (num > 0n) {
+      const rem = Number(num % ALPHABET_LENGTH);
+      out[i--] = BASE58_ALPHABET[rem]!;
+      num /= ALPHABET_LENGTH;
+  }
 
-  return encoded.padStart(22, BASE58_ALPHABET[0]);
+  return out.join("");
 }
 
 /**


### PR DESCRIPTION
This PR replaces the `uuid58EncodeSafe` implementation, which used prefix string concatenation in a loop, with a more efficient array-based approach. Complexity reduced from **O(n²)** to **O(n)**.

Prefix string concatenation allocates and copies strings on every iteration. Even though the length is fixed (22), this is still less optimal and unnecessary. The new implementation performs a single allocation and linear writes.
