### PR TITLE
chore: replace "npx jsr publish" with "deno publish"

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,8 +29,8 @@ jobs:
       - name: Build for npm
         run: deno task build
 
-      - name: Publish to jsr
-        run: npx jsr publish
+      - name: Publish to JSR
+        run: deno publish
 
       - name: Setup Node.js
         uses: actions/setup-node@v6


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Update publish workflow to use `deno publish` for JSR instead of `npx jsr publish`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5629108b0e8012bf47978f759553c3b4bf557ae9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->