### PR TITLE
chore: fix publint

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,6 @@
 {
   "recommendations": [
-    "streetsidesoftware.code-spell-checker",
-    "denoland.vscode-deno"
+    "denoland.vscode-deno",
+    "streetsidesoftware.code-spell-checker"
   ]
 }

--- a/build.ts
+++ b/build.ts
@@ -33,11 +33,12 @@ await build({
     version: config.version,
     license: config.license,
     sideEffects: false,
+    type: "module",
     description:
       "A tiny, zero-dependency library for generating and converting UUIDs to Base58-encoded strings.",
     repository: {
       type: "git",
-      url: "git://github.com/nakanoasaservice/uuid58.git",
+      url: "git+https://github.com/nakanoasaservice/uuid58.git",
     },
     bugs: {
       url: "https://github.com/nakanoasaservice/uuid58/issues",

--- a/deno.json
+++ b/deno.json
@@ -1,10 +1,10 @@
 {
-  "version": "1.0.4",
+  "version": "1.0.5",
   "name": "@nakanoaas/uuid58",
   "license": "MIT",
   "exports": "./index.ts",
   "tasks": {
-    "build": "deno run --allow-env --allow-read --allow-write --allow-run='npm' build.ts",
+    "build": "deno run --allow-env --allow-read --allow-write --allow-run=npm build.ts",
     "benchmark": "deno bench benchmark.ts"
   },
   "publish": {
@@ -28,6 +28,6 @@
   "imports": {
     "@deno/dnt": "jsr:@deno/dnt@^0.42.3",
     "@std/expect": "jsr:@std/expect@^1.0.17",
-    "@std/testing": "jsr:@std/testing@^1.0.15"
+    "@std/testing": "jsr:@std/testing@^1.0.16"
   }
 }

--- a/deno.lock
+++ b/deno.lock
@@ -3,19 +3,20 @@
   "specifiers": {
     "jsr:@david/code-block-writer@^13.0.3": "13.0.3",
     "jsr:@deno/dnt@~0.42.3": "0.42.3",
-    "jsr:@std/assert@^1.0.13": "1.0.14",
-    "jsr:@std/assert@^1.0.14": "1.0.14",
+    "jsr:@std/assert@^1.0.14": "1.0.16",
+    "jsr:@std/assert@^1.0.15": "1.0.16",
     "jsr:@std/data-structures@^1.0.9": "1.0.9",
     "jsr:@std/expect@^1.0.17": "1.0.17",
     "jsr:@std/fmt@1": "1.0.8",
-    "jsr:@std/fs@1": "1.0.19",
-    "jsr:@std/fs@^1.0.19": "1.0.19",
-    "jsr:@std/internal@^1.0.10": "1.0.10",
-    "jsr:@std/internal@^1.0.9": "1.0.10",
-    "jsr:@std/path@1": "1.1.2",
+    "jsr:@std/fs@1": "1.0.20",
+    "jsr:@std/fs@^1.0.19": "1.0.20",
+    "jsr:@std/internal@^1.0.10": "1.0.12",
+    "jsr:@std/internal@^1.0.12": "1.0.12",
+    "jsr:@std/path@1": "1.1.3",
     "jsr:@std/path@^1.0.7": "1.0.8",
-    "jsr:@std/path@^1.1.1": "1.1.2",
-    "jsr:@std/testing@^1.0.15": "1.0.15",
+    "jsr:@std/path@^1.1.2": "1.1.3",
+    "jsr:@std/path@^1.1.3": "1.1.3",
+    "jsr:@std/testing@^1.0.16": "1.0.16",
     "jsr:@ts-morph/bootstrap@0.27": "0.27.0",
     "jsr:@ts-morph/common@0.27": "0.27.0"
   },
@@ -33,10 +34,10 @@
         "jsr:@ts-morph/bootstrap"
       ]
     },
-    "@std/assert@1.0.14": {
-      "integrity": "68d0d4a43b365abc927f45a9b85c639ea18a9fab96ad92281e493e4ed84abaa4",
+    "@std/assert@1.0.16": {
+      "integrity": "6a7272ed1eaa77defe76e5ff63ca705d9c495077e2d5fd0126d2b53fc5bd6532",
       "dependencies": [
-        "jsr:@std/internal@^1.0.10"
+        "jsr:@std/internal@^1.0.12"
       ]
     },
     "@std/data-structures@1.0.9": {
@@ -61,33 +62,33 @@
         "jsr:@std/path@^1.0.7"
       ]
     },
-    "@std/fs@1.0.19": {
-      "integrity": "051968c2b1eae4d2ea9f79a08a3845740ef6af10356aff43d3e2ef11ed09fb06",
+    "@std/fs@1.0.20": {
+      "integrity": "e953206aae48d46ee65e8783ded459f23bec7dd1f3879512911c35e5484ea187",
       "dependencies": [
-        "jsr:@std/internal@^1.0.9",
-        "jsr:@std/path@^1.1.1"
+        "jsr:@std/internal@^1.0.12",
+        "jsr:@std/path@^1.1.3"
       ]
     },
-    "@std/internal@1.0.10": {
-      "integrity": "e3be62ce42cab0e177c27698e5d9800122f67b766a0bea6ca4867886cbde8cf7"
+    "@std/internal@1.0.12": {
+      "integrity": "972a634fd5bc34b242024402972cd5143eac68d8dffaca5eaa4dba30ce17b027"
     },
     "@std/path@1.0.8": {
       "integrity": "548fa456bb6a04d3c1a1e7477986b6cffbce95102d0bb447c67c4ee70e0364be"
     },
-    "@std/path@1.1.2": {
-      "integrity": "c0b13b97dfe06546d5e16bf3966b1cadf92e1cc83e56ba5476ad8b498d9e3038",
+    "@std/path@1.1.3": {
+      "integrity": "b015962d82a5e6daea980c32b82d2c40142149639968549c649031a230b1afb3",
       "dependencies": [
-        "jsr:@std/internal@^1.0.10"
+        "jsr:@std/internal@^1.0.12"
       ]
     },
-    "@std/testing@1.0.15": {
-      "integrity": "a490169f5ccb0f3ae9c94fbc69d2cd43603f2cffb41713a85f99bbb0e3087cbc",
+    "@std/testing@1.0.16": {
+      "integrity": "a917ffdeb5924c9be436dc78bc32e511760e14d3a96e49c607fc5ecca86d0092",
       "dependencies": [
-        "jsr:@std/assert@^1.0.13",
+        "jsr:@std/assert@^1.0.15",
         "jsr:@std/data-structures",
         "jsr:@std/fs@^1.0.19",
-        "jsr:@std/internal@^1.0.10",
-        "jsr:@std/path@^1.1.1"
+        "jsr:@std/internal@^1.0.12",
+        "jsr:@std/path@^1.1.2"
       ]
     },
     "@ts-morph/bootstrap@0.27.0": {
@@ -108,7 +109,7 @@
     "dependencies": [
       "jsr:@deno/dnt@~0.42.3",
       "jsr:@std/expect@^1.0.17",
-      "jsr:@std/testing@^1.0.15"
+      "jsr:@std/testing@^1.0.16"
     ]
   }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Bumps to 1.0.5, sets `package.type` to `module`, fixes build task permission flag, updates repo URL, and refreshes std dependencies/lockfile.
> 
> - **Build/Package config**:
>   - Add `type: "module"` to generated `package` in `build.ts`.
>   - Update repository URL to `git+https://...` in `build.ts`.
>   - Bump version to `1.0.5` in `deno.json`.
>   - Fix `tasks.build` permission flag syntax to `--allow-run=npm` in `deno.json`.
> - **Dependencies**:
>   - Update `@std/testing` to `^1.0.16` in `deno.json` and bump related `@std/*` versions in `deno.lock`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3e2cb8f47774bff89960125007085204c5ad09e1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->