### PR TITLE
Add UUID58 validation functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ shorter, URL-safe identifiers while maintaining the uniqueness of UUIDs.
 
 - 🚀 Generate short, URL-safe identifiers (**fixed 22 characters**)
 - 🔄 Bidirectional conversion between UUID and Base58
-- ✅ Efficient validation functions for UUID58 strings
 - 🪶 Zero dependencies
 - 💪 Type-safe with TypeScript
 - 🔒 Uses native `crypto.getRandomValues()` for secure UUID generation
@@ -197,17 +196,17 @@ that are not exactly 22 characters long.
 class Uuid58DecodeError extends Error;
 ```
 
-### `isUuid58(value: string)`
+### `isUuid58(uuid58: string)`
 
 Checks if a given string is a valid UUID58-encodable string. This function
 efficiently validates without performing full decoding.
 
 ```typescript
-function isUuid58(value: string): boolean;
+function isUuid58(uuid58: string): boolean;
 ```
 
 - **Parameters:**
-  - `value`: The string to check
+  - `uuid58`: The string to check
 - **Returns:** `true` if the string is a valid UUID58 string, `false` otherwise
 - **Note:** This function validates:
   - Length (must be exactly 22 characters)

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ shorter, URL-safe identifiers while maintaining the uniqueness of UUIDs.
 
 - 🚀 Generate short, URL-safe identifiers (**fixed 22 characters**)
 - 🔄 Bidirectional conversion between UUID and Base58
+- ✅ Efficient validation functions for UUID58 strings
 - 🪶 Zero dependencies
 - 💪 Type-safe with TypeScript
 - 🔒 Uses native `crypto.getRandomValues()` for secure UUID generation
@@ -94,6 +95,15 @@ if (decodedSafe instanceof Uuid58DecodeError) {
 }
 // use decoded UUID
 console.log(decodedSafe);
+
+import { isUuid58, UUID58_REGEX } from "@nakanoaas/uuid58";
+
+// Validate UUID58 string without decoding
+const isValid = isUuid58("XDY9dmBbcMBXqcRvYw8xJ2"); // true
+const isValid2 = isUuid58("invalid"); // false
+
+// Or use regex pattern for validation
+const isValid3 = UUID58_REGEX.test("XDY9dmBbcMBXqcRvYw8xJ2"); // true
 ```
 
 ## API Reference
@@ -187,6 +197,34 @@ that are not exactly 22 characters long.
 class Uuid58DecodeError extends Error;
 ```
 
+### `isUuid58(value: string)`
+
+Checks if a given string is a valid UUID58-encodable string. This function
+efficiently validates without performing full decoding.
+
+```typescript
+function isUuid58(value: string): boolean;
+```
+
+- **Parameters:**
+  - `value`: The string to check
+- **Returns:** `true` if the string is a valid UUID58 string, `false` otherwise
+- **Note:** This function validates:
+  - Length (must be exactly 22 characters)
+  - Base58 alphabet characters only
+  - That the decoded value fits within 128 bits (UUID size)
+
+**Example:**
+
+```typescript
+import { isUuid58 } from "@nakanoaas/uuid58";
+
+isUuid58("XDY9dmBbcMBXqcRvYw8xJ2"); // true
+isUuid58("invalid"); // false
+isUuid58("O0lI"); // false (contains invalid characters)
+isUuid58("short"); // false (too short)
+```
+
 ### Alphabet and Utilities
 
 #### `UUID58_ALPHABET`
@@ -210,6 +248,11 @@ Base58 alphabet.
 ```typescript
 const UUID58_REGEX: RegExp; // /^[1-9A-HJ-NP-Za-km-z]{22}$/
 ```
+
+**Note:** While `UUID58_REGEX` can validate the format, `isUuid58()` provides
+more comprehensive validation by also checking that the decoded value fits
+within 128 bits. For simple format checks, the regex is sufficient; for complete
+validation, use `isUuid58()`.
 
 **Example:**
 

--- a/alphabet.test.ts
+++ b/alphabet.test.ts
@@ -59,6 +59,14 @@ describe("UUID58_ALPHABET", () => {
     // Last should be lowercase letters (excluding l)
     expect(UUID58_ALPHABET.slice(33)).toBe("abcdefghijkmnopqrstuvwxyz"); // cspell:disable-line
   });
+
+  it("is strictly increasing by character code", () => {
+    for (let i = 1; i < UUID58_ALPHABET.length; i++) {
+      const prev = UUID58_ALPHABET.charCodeAt(i - 1);
+      const current = UUID58_ALPHABET.charCodeAt(i);
+      expect(prev < current).toBe(true);
+    }
+  });
 });
 
 describe("UUID58_LENGTH", () => {

--- a/alphabet.test.ts
+++ b/alphabet.test.ts
@@ -1,7 +1,7 @@
 import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
 
-import { UUID58_ALPHABET, UUID58_LENGTH, UUID58_REGEX } from "./alphabet.ts";
+import { UUID58_ALPHABET, UUID58_LENGTH } from "./alphabet.ts";
 
 describe("UUID58_ALPHABET", () => {
   it("has exactly 58 characters", () => {
@@ -65,113 +65,5 @@ describe("UUID58_LENGTH", () => {
   it("equals the length of UUID58_ALPHABET as BigInt", () => {
     expect(UUID58_LENGTH).toBe(BigInt(UUID58_ALPHABET.length));
     expect(UUID58_LENGTH).toBe(58n);
-  });
-});
-
-describe("UUID58_REGEX", () => {
-  it("matches valid 22-character Base58 strings", () => {
-    const validStrings = [
-      "XDY9dmBbcMBXqcRvYw8xJ2",
-      "1111111111111111111111", // All "1" (represents leading zeros)
-      "zzzzzzzzzzzzzzzzzzzzzz", // All "z"
-      "123456789ABCDEFGHJKLMN", // Mixed case (cspell:disable-line)
-      "abcdefghijkmnopqrstuvw", // Lowercase only (cspell:disable-line)
-      "ABCDEFGHJKLMNPQRSTUVWX", // Uppercase only (cspell:disable-line)
-    ];
-
-    for (const str of validStrings) {
-      expect(UUID58_REGEX.test(str)).toBe(true);
-    }
-  });
-
-  it("does not match strings shorter than 22 characters", () => {
-    const invalidStrings = [
-      "",
-      "1",
-      "XDY9dmBbcMBXqcRvYw8xJ", // 21 characters
-      "123456789ABCDEFGHJKLM", // 21 characters (cspell:disable-line)
-    ];
-
-    for (const str of invalidStrings) {
-      expect(UUID58_REGEX.test(str)).toBe(false);
-    }
-  });
-
-  it("does not match strings longer than 22 characters", () => {
-    const invalidStrings = [
-      "XDY9dmBbcMBXqcRvYw8xJ22", // 23 characters
-      "11111111111111111111111", // 23 characters
-      "123456789ABCDEFGHJKLMNP", // 23 characters (cspell:disable-line)
-    ];
-
-    for (const str of invalidStrings) {
-      expect(UUID58_REGEX.test(str)).toBe(false);
-    }
-  });
-
-  it("does not match strings containing forbidden characters (0, O, I, l)", () => {
-    const invalidStrings = [
-      "0DY9dmBbcMBXqcRvYw8xJ2", // Contains "0"
-      "XDY9dmBbcMBXqcRvYw8xJO", // Contains "O"
-      "IDY9dmBbcMBXqcRvYw8xJ2", // Contains "I"
-      "XDY9dmBbcMBXqcRvYw8xl2", // Contains "l"
-      "0OIl0OIl0OIl0OIl0OIl0O", // Contains all forbidden characters
-    ];
-
-    for (const str of invalidStrings) {
-      expect(UUID58_REGEX.test(str)).toBe(false);
-    }
-  });
-
-  it("does not match strings containing non-alphanumeric characters", () => {
-    const invalidStrings = [
-      "XDY9dmBbcMBXqcRvYw8xJ-", // Contains hyphen
-      "XDY9dmBbcMBXqcRvYw8xJ_", // Contains underscore
-      "XDY9dmBbcMBXqcRvYw8xJ ", // Contains space
-      "XDY9dmBbcMBXqcRvYw8xJ.", // Contains period
-      "XDY9dmBbcMBXqcRvYw8xJ@", // Contains @
-      "XDY9dmBbcMBXqcRvYw8xJ#", // Contains #
-      "XDY9dmBbcMBXqcRvYw8xJ$", // Contains $
-    ];
-
-    for (const str of invalidStrings) {
-      expect(UUID58_REGEX.test(str)).toBe(false);
-    }
-  });
-
-  it("matches strings that start with '1' (representing leading zeros)", () => {
-    const validStrings = [
-      "1111111111111111111111", // All "1"
-      "1XDY9dmBbcMBXqcRvYw8xJ", // Starts with "1"
-      "123456789ABCDEFGHJKLMN", // Starts with "1" (cspell:disable-line)
-    ];
-
-    for (const str of validStrings) {
-      expect(UUID58_REGEX.test(str)).toBe(true);
-    }
-  });
-
-  it("does not match empty string", () => {
-    expect(UUID58_REGEX.test("")).toBe(false);
-  });
-
-  it("works with actual encoded UUID58 values", () => {
-    // These are real encoded UUIDs from the main test suite
-    const realEncodedUuids = [
-      "1111111111111111111111", // All zeros UUID
-      "7mTz9XK2YpQvNwRfJhLcBdG", // Example encoded UUID
-    ];
-
-    for (const str of realEncodedUuids) {
-      // Only test if the string is exactly 22 characters and uses valid Base58 chars
-      if (str.length === 22) {
-        const hasOnlyValidChars = [...str].every((char) =>
-          UUID58_ALPHABET.includes(char)
-        );
-        if (hasOnlyValidChars) {
-          expect(UUID58_REGEX.test(str)).toBe(true);
-        }
-      }
-    }
   });
 });

--- a/alphabet.ts
+++ b/alphabet.ts
@@ -23,12 +23,3 @@ export const UUID58_ALPHABET: string =
  * This is exported for internal use but not part of the public API.
  */
 export const UUID58_LENGTH: bigint = BigInt(UUID58_ALPHABET.length);
-
-/**
- * @internal
- * Fast lookup map from alphabet characters to their indices
- */
-export const BASE58_MAP: Record<string, bigint> = {};
-for (let i = 0; i < UUID58_ALPHABET.length; i++) {
-  BASE58_MAP[UUID58_ALPHABET[i]!] = BigInt(i);
-}

--- a/alphabet.ts
+++ b/alphabet.ts
@@ -25,18 +25,10 @@ export const UUID58_ALPHABET: string =
 export const UUID58_LENGTH: bigint = BigInt(UUID58_ALPHABET.length);
 
 /**
- * Regular expression pattern for validating UUID58 strings.
- *
- * This regex ensures that a string:
- * - Contains exactly 22 characters
- * - Uses only characters from the Base58 alphabet
- * - Does not start with leading zeros (represented as "1" in Base58)
- *
- * @example
- * ```typescript
- * const isValid = UUID58_REGEX.test("XDY9dmBbcMBXqcRvYw8xJ2"); // true
- * const isValid = UUID58_REGEX.test("invalid"); // false
- * const isValid = UUID58_REGEX.test("123"); // false (too short)
- * ```
+ * @internal
+ * Fast lookup map from alphabet characters to their indices
  */
-export const UUID58_REGEX: RegExp = /^[1-9A-HJ-NP-Za-km-z]{22}$/u;
+export const BASE58_MAP: Record<string, bigint> = {};
+for (let i = 0; i < UUID58_ALPHABET.length; i++) {
+  BASE58_MAP[UUID58_ALPHABET[i]!] = BigInt(i);
+}

--- a/benchmark.ts
+++ b/benchmark.ts
@@ -4,21 +4,24 @@ import { uuid58Decode } from "./decode.ts";
 import { uuid58Encode } from "./encode.ts";
 import { uuid58 } from "./generate.ts";
 
+const TEST_UUID = "f4b247fd-1f87-45d4-aa06-1c6fc0a8dfaf";
+const TEST_UUID58 = "XDY9dmBbcMBXqcRvYw8xJ2";
+
+// ============================================================================
+// Encode/Decode Functions
+// ============================================================================
+
 Deno.bench("uuid58Encode", () => {
-  uuid58Encode("f4b247fd-1f87-45d4-aa06-1c6fc0a8dfaf");
+  uuid58Encode(TEST_UUID);
 });
 
 Deno.bench("uuid58Decode", () => {
-  uuid58Decode("XDY9dmBbcMBXqcRvYw8xJ2");
+  uuid58Decode(TEST_UUID58);
 });
 
-Deno.bench("uuid58 (using crypto.getRandomValues)", () => {
-  uuid58();
-});
-
-Deno.bench("uuid58 (using crypto.randomUUID)", () => {
-  uuid58RandomUUID();
-});
+// ============================================================================
+// UUID58 Generation Functions
+// ============================================================================
 
 function uuid58RandomUUID(): string {
   let num = BigInt("0x" + crypto.randomUUID().replace(/-/g, ""));
@@ -32,20 +35,32 @@ function uuid58RandomUUID(): string {
   return encoded.padStart(22, UUID58_ALPHABET[0]);
 }
 
-Deno.bench("isUuid58", () => {
-  isUuid58("XDY9dmBbcMBXqcRvYw8xJ2");
+Deno.bench("uuid58", () => {
+  uuid58();
 });
 
-// UUID max value encoded in Base58 (length 22)
+Deno.bench("uuid58RandomUUID", () => {
+  uuid58RandomUUID();
+});
+
+// ============================================================================
+// UUID58 Validation Functions
+// ============================================================================
+
+const MAX_UUID_VALUE = (1n << 128n) - 1n;
 const MAX_UUID58 = "YcVfxkQb6JRzqk5kF2tNLv"; // cspell:disable-line
 const MAX_UUID58_CODES = Array.from(MAX_UUID58, (char) => char.charCodeAt(0));
+
+const BASE58_MAP: Record<string, bigint> = {};
+for (let i = 0; i < UUID58_ALPHABET.length; i++) {
+  BASE58_MAP[UUID58_ALPHABET[i]!] = BigInt(i);
+}
 
 function isUuid58Regex(value: string): boolean {
   if (!UUID58_REGEX.test(value)) {
     return false;
   }
 
-  // Compare chars against the max-UUID Base58 string using ASCII order
   let isBelowMax = false;
   for (let i = 0; i < value.length; i++) {
     const code = value.charCodeAt(i);
@@ -63,41 +78,69 @@ function isUuid58Regex(value: string): boolean {
   return true;
 }
 
-Deno.bench("isUuid58Regex", () => {
-  isUuid58Regex("XDY9dmBbcMBXqcRvYw8xJ2");
-});
-
-const MAX_UUID_VALUE = (1n << 128n) - 1n;
-const BASE58_MAP: Record<string, bigint> = {};
-for (let i = 0; i < UUID58_ALPHABET.length; i++) {
-  BASE58_MAP[UUID58_ALPHABET[i]!] = BigInt(i);
-}
-
-export function isUuid58Naive(value: string): boolean {
-  // Check length: UUID58 strings must be exactly 22 characters
+function isUuid58RangeList(value: string): boolean {
   if (value.length !== 22) {
     return false;
   }
 
-  // Convert Base58 string to BigInt and check if it's within UUID range
+  let isBelowMax = false;
+  for (let i = 0; i < value.length; i++) {
+    const code = value.charCodeAt(i);
+    const isValid = (code >= 49 && code <= 57) || // '1'..'9'
+      (code >= 65 && code <= 72) || // 'A'..'H'
+      (code >= 74 && code <= 78) || // 'J'..'N'
+      (code >= 80 && code <= 90) || // 'P'..'Z'
+      (code >= 97 && code <= 107) || // 'a'..'k'
+      (code >= 109 && code <= 122); // 'm'..'z'
+    if (!isValid) {
+      return false;
+    }
+
+    if (!isBelowMax) {
+      const maxCode = MAX_UUID58_CODES[i]!;
+      if (code < maxCode) {
+        isBelowMax = true;
+      } else if (code > maxCode) {
+        return false;
+      }
+    }
+  }
+
+  return true;
+}
+
+function isUuid58Naive(value: string): boolean {
+  if (value.length !== 22) {
+    return false;
+  }
+
   let num = 0n;
   for (const char of value) {
     const index = BASE58_MAP[char];
-    // Check if character is in the Base58 alphabet
     if (index === undefined) {
       return false;
     }
     num = num * UUID58_LENGTH + index;
-    // Early exit: if we exceed the maximum UUID value, it's invalid
     if (num > MAX_UUID_VALUE) {
       return false;
     }
   }
 
-  // Verify the decoded value fits within 128 bits
   return num <= MAX_UUID_VALUE;
 }
 
+Deno.bench("isUuid58", () => {
+  isUuid58(TEST_UUID58);
+});
+
+Deno.bench("isUuid58Regex", () => {
+  isUuid58Regex(TEST_UUID58);
+});
+
+Deno.bench("isUuid58RangeList", () => {
+  isUuid58RangeList(TEST_UUID58);
+});
+
 Deno.bench("isUuid58Naive", () => {
-  isUuid58Naive("XDY9dmBbcMBXqcRvYw8xJ2");
+  isUuid58Naive(TEST_UUID58);
 });

--- a/benchmark.ts
+++ b/benchmark.ts
@@ -1,4 +1,5 @@
 import { UUID58_ALPHABET, UUID58_LENGTH } from "./alphabet.ts";
+import { isUuid58, UUID58_REGEX } from "./check.ts";
 import { uuid58Decode } from "./decode.ts";
 import { uuid58Encode } from "./encode.ts";
 import { uuid58 } from "./generate.ts";
@@ -30,3 +31,73 @@ function uuid58RandomUUID(): string {
 
   return encoded.padStart(22, UUID58_ALPHABET[0]);
 }
+
+Deno.bench("isUuid58", () => {
+  isUuid58("XDY9dmBbcMBXqcRvYw8xJ2");
+});
+
+// UUID max value encoded in Base58 (length 22)
+const MAX_UUID58 = "YcVfxkQb6JRzqk5kF2tNLv"; // cspell:disable-line
+const MAX_UUID58_CODES = Array.from(MAX_UUID58, (char) => char.charCodeAt(0));
+
+function isUuid58Regex(value: string): boolean {
+  if (!UUID58_REGEX.test(value)) {
+    return false;
+  }
+
+  // Compare chars against the max-UUID Base58 string using ASCII order
+  let isBelowMax = false;
+  for (let i = 0; i < value.length; i++) {
+    const code = value.charCodeAt(i);
+
+    if (!isBelowMax) {
+      const maxCode = MAX_UUID58_CODES[i]!;
+      if (code < maxCode) {
+        isBelowMax = true;
+      } else if (code > maxCode) {
+        return false;
+      }
+    }
+  }
+
+  return true;
+}
+
+Deno.bench("isUuid58Regex", () => {
+  isUuid58Regex("XDY9dmBbcMBXqcRvYw8xJ2");
+});
+
+const MAX_UUID_VALUE = (1n << 128n) - 1n;
+const BASE58_MAP: Record<string, bigint> = {};
+for (let i = 0; i < UUID58_ALPHABET.length; i++) {
+  BASE58_MAP[UUID58_ALPHABET[i]!] = BigInt(i);
+}
+
+export function isUuid58Naive(value: string): boolean {
+  // Check length: UUID58 strings must be exactly 22 characters
+  if (value.length !== 22) {
+    return false;
+  }
+
+  // Convert Base58 string to BigInt and check if it's within UUID range
+  let num = 0n;
+  for (const char of value) {
+    const index = BASE58_MAP[char];
+    // Check if character is in the Base58 alphabet
+    if (index === undefined) {
+      return false;
+    }
+    num = num * UUID58_LENGTH + index;
+    // Early exit: if we exceed the maximum UUID value, it's invalid
+    if (num > MAX_UUID_VALUE) {
+      return false;
+    }
+  }
+
+  // Verify the decoded value fits within 128 bits
+  return num <= MAX_UUID_VALUE;
+}
+
+Deno.bench("isUuid58Naive", () => {
+  isUuid58Naive("XDY9dmBbcMBXqcRvYw8xJ2");
+});

--- a/check.test.ts
+++ b/check.test.ts
@@ -15,6 +15,24 @@ const validUuids = [
 ];
 
 describe("isUuid58", () => {
+  describe("boundary values", () => {
+    it("returns true for minimum UUID value (all zeros)", () => {
+      const minUuid = "00000000-0000-0000-0000-000000000000";
+      const encoded = uuid58Encode(minUuid);
+      expect(isUuid58(encoded)).toBe(true);
+      expect(encoded).toBe("1111111111111111111111");
+    });
+
+    it("returns true for maximum UUID value", () => {
+      expect(isUuid58("YcVfxkQb6JRzqk5kF2tNLv")).toBe(true); // cspell:disable-line
+    });
+
+    it("returns false for max UUID value plus one", () => {
+      // MAX_UUID58 + 1
+      expect(isUuid58("YcVfxkQb6JRzqk5kF2tNLw")).toBe(false); // cspell:disable-line
+    });
+  });
+
   describe("valid UUID58 strings", () => {
     it("returns true for valid encoded UUID strings", () => {
       for (const uuid of validUuids) {
@@ -23,17 +41,13 @@ describe("isUuid58", () => {
       }
     });
 
-    it("returns true for minimum UUID value (all zeros)", () => {
-      const minUuid = "00000000-0000-0000-0000-000000000000";
-      const encoded = uuid58Encode(minUuid);
-      expect(isUuid58(encoded)).toBe(true);
-      expect(encoded).toBe("1111111111111111111111");
-    });
+    it("returns true for valid 22-character Base58 strings", () => {
+      // All '1' characters (minimum Base58 value, represents zero)
+      expect(isUuid58("1111111111111111111111")).toBe(true);
 
-    it("returns true for maximum UUID value (all ff)", () => {
-      const maxUuid = "ffffffff-ffff-ffff-ffff-ffffffffffff";
-      const encoded = uuid58Encode(maxUuid);
-      expect(isUuid58(encoded)).toBe(true);
+      // Mixed valid characters that decode to valid UUIDs
+      expect(isUuid58("123456789ABCDEFGHJKLMN")).toBe(true); // cspell:disable-line
+      expect(isUuid58("PQRSTUVWXYZabcdefghijk")).toBe(true); // cspell:disable-line
     });
   });
 
@@ -43,12 +57,14 @@ describe("isUuid58", () => {
       expect(isUuid58("short")).toBe(false);
       expect(isUuid58("UoWww8DGaVGLtea7zU7p")).toBe(false); // 21 characters
       expect(isUuid58("123456789012345678901")).toBe(false); // 21 characters
+      expect(isUuid58("123456789ABCDEFGHJKLM")).toBe(false); // 21 characters (cspell:disable-line)
     });
 
     it("returns false for strings longer than 22 characters", () => {
       expect(isUuid58("11111111111111111111111")).toBe(false); // 23 characters
       expect(isUuid58("1111UoWww8DGaVGLtea7zU7p")).toBe(false); // 26 characters
       expect(isUuid58("12345678901234567890123")).toBe(false); // 23 characters
+      expect(isUuid58("123456789ABCDEFGHJKLMNP")).toBe(false); // 23 characters (cspell:disable-line)
     });
   });
 
@@ -78,10 +94,6 @@ describe("isUuid58", () => {
   });
 
   describe("values exceeding 128 bits", () => {
-    it("returns true for max UUID value", () => {
-      expect(isUuid58("YcVfxkQb6JRzqk5kF2tNLv")).toBe(true); // cspell:disable-line
-    });
-
     it("returns false for Base58 strings that decode to values exceeding 128 bits", () => {
       // 22 'z' characters (maximum Base58 value) exceeds 128 bits
       expect(isUuid58("zzzzzzzzzzzzzzzzzzzzzz")).toBe(false);
@@ -94,27 +106,6 @@ describe("isUuid58", () => {
     it("returns false for strings that would exceed 128 bits during decoding", () => {
       // A string that starts with high-value characters
       expect(isUuid58("zzzzzzzzzzzzzzzzzzzzz1")).toBe(false);
-    });
-
-    it("returns false for max UUID value plus one", () => {
-      // MAX_UUID58 + 1
-      expect(isUuid58("YcVfxkQb6JRzqk5kF2tNLw")).toBe(false); // cspell:disable-line
-    });
-  });
-
-  describe("edge cases", () => {
-    it("returns true for valid 22-character Base58 strings", () => {
-      // All '1' characters (minimum Base58 value, represents zero)
-      expect(isUuid58("1111111111111111111111")).toBe(true);
-
-      // Mixed valid characters that decode to valid UUIDs
-      expect(isUuid58("123456789ABCDEFGHJKLMN")).toBe(true); // cspell:disable-line
-      expect(isUuid58("PQRSTUVWXYZabcdefghijk")).toBe(true); // cspell:disable-line
-    });
-
-    it("returns false for strings with only valid characters but wrong length", () => {
-      expect(isUuid58("123456789ABCDEFGHJKLM")).toBe(false); // 21 characters (cspell:disable-line)
-      expect(isUuid58("123456789ABCDEFGHJKLMNP")).toBe(false); // 23 characters (cspell:disable-line)
     });
   });
 

--- a/check.test.ts
+++ b/check.test.ts
@@ -1,0 +1,245 @@
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import { isUuid58, UUID58_REGEX } from "./check.ts";
+import { UUID58_ALPHABET } from "./alphabet.ts";
+import { uuid58Encode } from "./encode.ts";
+import { uuid58DecodeSafe } from "./decode.ts";
+
+const validUuids = [
+  "00000000-0000-0000-0000-000000000000", // All zeros
+  "ffffffff-ffff-ffff-ffff-ffffffffffff", // All ff
+  "f4b247fd-1f87-45d4-aa06-1c6fc0a8dfaf", // Random
+  "123e4567-e89b-12d3-a456-426614174000", // RFC 4122 example
+  "00112233-4455-6677-8899-aabbccddeeff", // Contains leading 00 bytes
+];
+
+describe("isUuid58", () => {
+  describe("valid UUID58 strings", () => {
+    it("returns true for valid encoded UUID strings", () => {
+      for (const uuid of validUuids) {
+        const encoded = uuid58Encode(uuid);
+        expect(isUuid58(encoded)).toBe(true);
+      }
+    });
+
+    it("returns true for minimum UUID value (all zeros)", () => {
+      const minUuid = "00000000-0000-0000-0000-000000000000";
+      const encoded = uuid58Encode(minUuid);
+      expect(isUuid58(encoded)).toBe(true);
+      expect(encoded).toBe("1111111111111111111111");
+    });
+
+    it("returns true for maximum UUID value (all ff)", () => {
+      const maxUuid = "ffffffff-ffff-ffff-ffff-ffffffffffff";
+      const encoded = uuid58Encode(maxUuid);
+      expect(isUuid58(encoded)).toBe(true);
+    });
+  });
+
+  describe("invalid length", () => {
+    it("returns false for strings shorter than 22 characters", () => {
+      expect(isUuid58("")).toBe(false);
+      expect(isUuid58("short")).toBe(false);
+      expect(isUuid58("UoWww8DGaVGLtea7zU7p")).toBe(false); // 21 characters
+      expect(isUuid58("123456789012345678901")).toBe(false); // 21 characters
+    });
+
+    it("returns false for strings longer than 22 characters", () => {
+      expect(isUuid58("11111111111111111111111")).toBe(false); // 23 characters
+      expect(isUuid58("1111UoWww8DGaVGLtea7zU7p")).toBe(false); // 26 characters
+      expect(isUuid58("12345678901234567890123")).toBe(false); // 23 characters
+    });
+  });
+
+  describe("invalid characters", () => {
+    it("returns false for strings containing forbidden Base58 characters", () => {
+      expect(isUuid58("O0lI111111111111111111")).toBe(false); // Contains O, 0, l, I
+      expect(isUuid58("$$$111111111111111111")).toBe(false); // Contains special characters
+      expect(isUuid58("invalid11111111111111")).toBe(false); // Contains invalid characters
+      expect(isUuid58("11111111111111111111O0")).toBe(false); // Contains O and 0 at the end
+    });
+
+    it("returns false for strings containing lowercase 'l'", () => {
+      expect(isUuid58("11111111111111111111l1")).toBe(false);
+    });
+
+    it("returns false for strings containing uppercase 'I'", () => {
+      expect(isUuid58("11111111111111111111I1")).toBe(false);
+    });
+
+    it("returns false for strings containing uppercase 'O'", () => {
+      expect(isUuid58("11111111111111111111O1")).toBe(false);
+    });
+
+    it("returns false for strings containing digit '0'", () => {
+      expect(isUuid58("1111111111111111111101")).toBe(false);
+    });
+  });
+
+  describe("values exceeding 128 bits", () => {
+    it("returns false for Base58 strings that decode to values exceeding 128 bits", () => {
+      // 22 'z' characters (maximum Base58 value) exceeds 128 bits
+      expect(isUuid58("zzzzzzzzzzzzzzzzzzzzzz")).toBe(false);
+      
+      // Verify that decode also fails for this value
+      const decodeResult = uuid58DecodeSafe("zzzzzzzzzzzzzzzzzzzzzz");
+      expect(decodeResult).toBeInstanceOf(Error);
+    });
+
+    it("returns false for strings that would exceed 128 bits during decoding", () => {
+      // A string that starts with high-value characters
+      expect(isUuid58("zzzzzzzzzzzzzzzzzzzzz1")).toBe(false);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("returns true for valid 22-character Base58 strings", () => {
+      // All '1' characters (minimum Base58 value, represents zero)
+      expect(isUuid58("1111111111111111111111")).toBe(true);
+      
+      // Mixed valid characters that decode to valid UUIDs
+      expect(isUuid58("123456789ABCDEFGHJKLMN")).toBe(true);
+      expect(isUuid58("PQRSTUVWXYZabcdefghijk")).toBe(true);
+    });
+
+    it("returns false for strings with only valid characters but wrong length", () => {
+      expect(isUuid58("123456789ABCDEFGHJKLM")).toBe(false); // 21 characters
+      expect(isUuid58("123456789ABCDEFGHJKLMNP")).toBe(false); // 23 characters
+    });
+  });
+
+  describe("consistency with decode function", () => {
+    it("returns true for strings that can be decoded successfully", () => {
+      for (const uuid of validUuids) {
+        const encoded = uuid58Encode(uuid);
+        const decodeResult = uuid58DecodeSafe(encoded);
+        expect(decodeResult).not.toBeInstanceOf(Error);
+        expect(isUuid58(encoded)).toBe(true);
+      }
+    });
+
+    it("returns false for strings that fail to decode", () => {
+      const invalidStrings = [
+        "O0lI111111111111111111", // Invalid characters
+        "short", // Too short
+        "11111111111111111111111", // Too long
+        "zzzzzzzzzzzzzzzzzzzzzz", // Exceeds 128 bits
+      ];
+
+      for (const invalid of invalidStrings) {
+        const decodeResult = uuid58DecodeSafe(invalid);
+        expect(decodeResult).toBeInstanceOf(Error);
+        expect(isUuid58(invalid)).toBe(false);
+      }
+    });
+  });
+});
+
+describe("UUID58_REGEX", () => {
+  it("matches valid 22-character Base58 strings", () => {
+    const validStrings = [
+      "XDY9dmBbcMBXqcRvYw8xJ2",
+      "1111111111111111111111", // All "1" (represents leading zeros)
+      "zzzzzzzzzzzzzzzzzzzzzz", // All "z"
+      "123456789ABCDEFGHJKLMN", // Mixed case (cspell:disable-line)
+      "abcdefghijkmnopqrstuvw", // Lowercase only (cspell:disable-line)
+      "ABCDEFGHJKLMNPQRSTUVWX", // Uppercase only (cspell:disable-line)
+    ];
+
+    for (const str of validStrings) {
+      expect(UUID58_REGEX.test(str)).toBe(true);
+    }
+  });
+
+  it("does not match strings shorter than 22 characters", () => {
+    const invalidStrings = [
+      "",
+      "1",
+      "XDY9dmBbcMBXqcRvYw8xJ", // 21 characters
+      "123456789ABCDEFGHJKLM", // 21 characters (cspell:disable-line)
+    ];
+
+    for (const str of invalidStrings) {
+      expect(UUID58_REGEX.test(str)).toBe(false);
+    }
+  });
+
+  it("does not match strings longer than 22 characters", () => {
+    const invalidStrings = [
+      "XDY9dmBbcMBXqcRvYw8xJ22", // 23 characters
+      "11111111111111111111111", // 23 characters
+      "123456789ABCDEFGHJKLMNP", // 23 characters (cspell:disable-line)
+    ];
+
+    for (const str of invalidStrings) {
+      expect(UUID58_REGEX.test(str)).toBe(false);
+    }
+  });
+
+  it("does not match strings containing forbidden characters (0, O, I, l)", () => {
+    const invalidStrings = [
+      "0DY9dmBbcMBXqcRvYw8xJ2", // Contains "0"
+      "XDY9dmBbcMBXqcRvYw8xJO", // Contains "O"
+      "IDY9dmBbcMBXqcRvYw8xJ2", // Contains "I"
+      "XDY9dmBbcMBXqcRvYw8xl2", // Contains "l"
+      "0OIl0OIl0OIl0OIl0OIl0O", // Contains all forbidden characters
+    ];
+
+    for (const str of invalidStrings) {
+      expect(UUID58_REGEX.test(str)).toBe(false);
+    }
+  });
+
+  it("does not match strings containing non-alphanumeric characters", () => {
+    const invalidStrings = [
+      "XDY9dmBbcMBXqcRvYw8xJ-", // Contains hyphen
+      "XDY9dmBbcMBXqcRvYw8xJ_", // Contains underscore
+      "XDY9dmBbcMBXqcRvYw8xJ ", // Contains space
+      "XDY9dmBbcMBXqcRvYw8xJ.", // Contains period
+      "XDY9dmBbcMBXqcRvYw8xJ@", // Contains @
+      "XDY9dmBbcMBXqcRvYw8xJ#", // Contains #
+      "XDY9dmBbcMBXqcRvYw8xJ$", // Contains $
+    ];
+
+    for (const str of invalidStrings) {
+      expect(UUID58_REGEX.test(str)).toBe(false);
+    }
+  });
+
+  it("matches strings that start with '1' (representing leading zeros)", () => {
+    const validStrings = [
+      "1111111111111111111111", // All "1"
+      "1XDY9dmBbcMBXqcRvYw8xJ", // Starts with "1"
+      "123456789ABCDEFGHJKLMN", // Starts with "1" (cspell:disable-line)
+    ];
+
+    for (const str of validStrings) {
+      expect(UUID58_REGEX.test(str)).toBe(true);
+    }
+  });
+
+  it("does not match empty string", () => {
+    expect(UUID58_REGEX.test("")).toBe(false);
+  });
+
+  it("works with actual encoded UUID58 values", () => {
+    // These are real encoded UUIDs from the main test suite
+    const realEncodedUuids = [
+      "1111111111111111111111", // All zeros UUID
+      "7mTz9XK2YpQvNwRfJhLcBdG", // Example encoded UUID
+    ];
+
+    for (const str of realEncodedUuids) {
+      // Only test if the string is exactly 22 characters and uses valid Base58 chars
+      if (str.length === 22) {
+        const hasOnlyValidChars = [...str].every((char) =>
+          UUID58_ALPHABET.includes(char)
+        );
+        if (hasOnlyValidChars) {
+          expect(UUID58_REGEX.test(str)).toBe(true);
+        }
+      }
+    }
+  });
+});

--- a/check.test.ts
+++ b/check.test.ts
@@ -78,10 +78,14 @@ describe("isUuid58", () => {
   });
 
   describe("values exceeding 128 bits", () => {
+    it("returns true for max UUID value", () => {
+      expect(isUuid58("YcVfxkQb6JRzqk5kF2tNLv")).toBe(true); // cspell:disable-line
+    });
+
     it("returns false for Base58 strings that decode to values exceeding 128 bits", () => {
       // 22 'z' characters (maximum Base58 value) exceeds 128 bits
       expect(isUuid58("zzzzzzzzzzzzzzzzzzzzzz")).toBe(false);
-      
+
       // Verify that decode also fails for this value
       const decodeResult = uuid58DecodeSafe("zzzzzzzzzzzzzzzzzzzzzz");
       expect(decodeResult).toBeInstanceOf(Error);
@@ -91,21 +95,26 @@ describe("isUuid58", () => {
       // A string that starts with high-value characters
       expect(isUuid58("zzzzzzzzzzzzzzzzzzzzz1")).toBe(false);
     });
+
+    it("returns false for max UUID value plus one", () => {
+      // MAX_UUID58 + 1
+      expect(isUuid58("YcVfxkQb6JRzqk5kF2tNLw")).toBe(false); // cspell:disable-line
+    });
   });
 
   describe("edge cases", () => {
     it("returns true for valid 22-character Base58 strings", () => {
       // All '1' characters (minimum Base58 value, represents zero)
       expect(isUuid58("1111111111111111111111")).toBe(true);
-      
+
       // Mixed valid characters that decode to valid UUIDs
-      expect(isUuid58("123456789ABCDEFGHJKLMN")).toBe(true);
-      expect(isUuid58("PQRSTUVWXYZabcdefghijk")).toBe(true);
+      expect(isUuid58("123456789ABCDEFGHJKLMN")).toBe(true); // cspell:disable-line
+      expect(isUuid58("PQRSTUVWXYZabcdefghijk")).toBe(true); // cspell:disable-line
     });
 
     it("returns false for strings with only valid characters but wrong length", () => {
-      expect(isUuid58("123456789ABCDEFGHJKLM")).toBe(false); // 21 characters
-      expect(isUuid58("123456789ABCDEFGHJKLMNP")).toBe(false); // 23 characters
+      expect(isUuid58("123456789ABCDEFGHJKLM")).toBe(false); // 21 characters (cspell:disable-line)
+      expect(isUuid58("123456789ABCDEFGHJKLMNP")).toBe(false); // 23 characters (cspell:disable-line)
     });
   });
 

--- a/check.ts
+++ b/check.ts
@@ -1,0 +1,65 @@
+import { BASE58_MAP, UUID58_LENGTH } from "./alphabet.ts";
+
+// Maximum value for a 128-bit UUID (2^128 - 1)
+const MAX_UUID_VALUE = (1n << 128n) - 1n;
+
+/**
+ * Checks if a given string is a valid UUID58-encodable string.
+ * This function efficiently validates without performing full decoding.
+ *
+ * A valid UUID58 string must:
+ * - Be exactly 22 characters long
+ * - Contain only characters from the Base58 alphabet
+ * - Decode to a value that fits within 128 bits (UUID size)
+ *
+ * @param value - The string to check
+ * @returns `true` if the string is a valid UUID58 string, `false` otherwise
+ *
+ * @example
+ * ```typescript
+ * isUuid58("XDY9dmBbcMBXqcRvYw8xJ2"); // true
+ * isUuid58("invalid"); // false
+ * isUuid58("O0lI"); // false (contains invalid characters)
+ * ```
+ */
+export function isUuid58(value: string): boolean {
+  // Check length: UUID58 strings must be exactly 22 characters
+  if (value.length !== 22) {
+    return false;
+  }
+
+  // Convert Base58 string to BigInt and check if it's within UUID range
+  let num = 0n;
+  for (const char of value) {
+    const index = BASE58_MAP[char];
+    // Check if character is in the Base58 alphabet
+    if (index === undefined) {
+      return false;
+    }
+    num = num * UUID58_LENGTH + index;
+    // Early exit: if we exceed the maximum UUID value, it's invalid
+    if (num > MAX_UUID_VALUE) {
+      return false;
+    }
+  }
+
+  // Verify the decoded value fits within 128 bits
+  return num <= MAX_UUID_VALUE;
+}
+
+/**
+ * Regular expression pattern for validating UUID58 strings.
+ *
+ * This regex ensures that a string:
+ * - Contains exactly 22 characters
+ * - Uses only characters from the Base58 alphabet
+ * - Does not start with leading zeros (represented as "1" in Base58)
+ *
+ * @example
+ * ```typescript
+ * const isValid = UUID58_REGEX.test("XDY9dmBbcMBXqcRvYw8xJ2"); // true
+ * const isValid = UUID58_REGEX.test("invalid"); // false
+ * const isValid = UUID58_REGEX.test("123"); // false (too short)
+ * ```
+ */
+export const UUID58_REGEX: RegExp = /^[1-9A-HJ-NP-Za-km-z]{22}$/u;

--- a/check.ts
+++ b/check.ts
@@ -13,7 +13,7 @@ const MAX_UUID58_CODES = Array.from(
  * - Contain only characters from the Base58 alphabet
  * - Decode to a value that fits within 128 bits (UUID size)
  *
- * @param value - The string to check
+ * @param uuid58 - The string to check
  * @returns `true` if the string is a valid UUID58 string, `false` otherwise
  *
  * @example
@@ -23,16 +23,16 @@ const MAX_UUID58_CODES = Array.from(
  * isUuid58("O0lI"); // false (contains invalid characters)
  * ```
  */
-export function isUuid58(value: string): boolean {
+export function isUuid58(uuid58: string): boolean {
   // Check length: UUID58 strings must be exactly 22 characters
-  if (value.length !== 22) {
+  if (uuid58.length !== 22) {
     return false;
   }
 
   // Compare chars against the max-UUID Base58 string using ASCII order
   let isBelowMax = false;
   for (let i = 0; i < 22; i++) {
-    const code = value.charCodeAt(i);
+    const code = uuid58.charCodeAt(i);
     // Check if character is in the Bitcoin Base58 alphabet
     const isValid = (code >= 49 && code <= 57) || // '1'..'9'
       (code >= 65 && code <= 72) || // 'A'..'H'

--- a/check.ts
+++ b/check.ts
@@ -62,7 +62,10 @@ export function isUuid58(value: string): boolean {
  * This regex ensures that a string:
  * - Contains exactly 22 characters
  * - Uses only characters from the Base58 alphabet
- * - Does not start with leading zeros (represented as "1" in Base58)
+ *
+ * **Note:** This regex does NOT validate that the decoded value fits within
+ * 128 bits (UUID size). For complete validation including 128-bit range
+ * checking, use {@link isUuid58} instead.
  *
  * @example
  * ```typescript

--- a/check.ts
+++ b/check.ts
@@ -33,16 +33,22 @@ export function isUuid58(uuid58: string): boolean {
   let isBelowMax = false;
   for (let i = 0; i < 22; i++) {
     const code = uuid58.charCodeAt(i);
+
     // Check if character is in the Bitcoin Base58 alphabet
-    const isValid = (code >= 49 && code <= 57) || // '1'..'9'
-      (code >= 65 && code <= 72) || // 'A'..'H'
-      (code >= 74 && code <= 78) || // 'J'..'N'
-      (code >= 80 && code <= 90) || // 'P'..'Z'
-      (code >= 97 && code <= 107) || // 'a'..'k'
-      (code >= 109 && code <= 122); // 'm'..'z'
-    if (!isValid) {
+    if (
+      // Exclude characters outside the range 49..122
+      code < 49 ||
+      code > 122 ||
+      // Exclude gaps and ambiguous characters within 49..122
+      (code >= 58 && code <= 64) || // ':'..'@'
+      code === 73 || // 'I'
+      code === 79 || // 'O'
+      (code >= 91 && code <= 96) || // '['..'`'
+      code === 108 // 'l'
+    ) {
       return false;
     }
+
     if (!isBelowMax) {
       const maxCode = MAX_UUID58_CODES[i]!;
       if (code < maxCode) {

--- a/check.ts
+++ b/check.ts
@@ -36,15 +36,13 @@ export function isUuid58(uuid58: string): boolean {
 
     // Check if character is in the Bitcoin Base58 alphabet
     if (
-      // Exclude characters outside the range 49..122
       code < 49 ||
-      code > 122 ||
-      // Exclude gaps and ambiguous characters within 49..122
       (code >= 58 && code <= 64) || // ':'..'@'
       code === 73 || // 'I'
       code === 79 || // 'O'
       (code >= 91 && code <= 96) || // '['..'`'
-      code === 108 // 'l'
+      code === 108 || // 'l'
+      code > 122
     ) {
       return false;
     }

--- a/decode.ts
+++ b/decode.ts
@@ -1,4 +1,10 @@
-import { BASE58_MAP, UUID58_LENGTH } from "./alphabet.ts";
+import { UUID58_ALPHABET, UUID58_LENGTH } from "./alphabet.ts";
+
+// Fast lookup map from alphabet characters to their indices
+const BASE58_MAP: Record<string, bigint> = {};
+for (let i = 0; i < UUID58_ALPHABET.length; i++) {
+  BASE58_MAP[UUID58_ALPHABET[i]!] = BigInt(i);
+}
 
 /**
  * Error thrown when an invalid Base58 string is provided for decoding.

--- a/decode.ts
+++ b/decode.ts
@@ -1,10 +1,4 @@
-import { UUID58_ALPHABET, UUID58_LENGTH } from "./alphabet.ts";
-
-// Fast lookup map from alphabet characters to their indices
-const BASE58_MAP: Record<string, bigint> = {};
-for (let i = 0; i < UUID58_ALPHABET.length; i++) {
-  BASE58_MAP[UUID58_ALPHABET[i]!] = BigInt(i);
-}
+import { BASE58_MAP, UUID58_LENGTH } from "./alphabet.ts";
 
 /**
  * Error thrown when an invalid Base58 string is provided for decoding.

--- a/deno.json
+++ b/deno.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.0",
+  "version": "1.2.0",
   "name": "@nakanoaas/uuid58",
   "license": "MIT",
   "exports": "./index.ts",
@@ -10,6 +10,7 @@
   "publish": {
     "include": [
       "alphabet.ts",
+      "check.ts",
       "decode.ts",
       "encode.ts",
       "generate.ts",

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,5 @@
-export { UUID58_ALPHABET, UUID58_REGEX } from "./alphabet.ts";
+export { UUID58_ALPHABET } from "./alphabet.ts";
+export * from "./check.ts";
 export * from "./decode.ts";
 export * from "./encode.ts";
 export * from "./generate.ts";


### PR DESCRIPTION
## Summary

This PR adds efficient validation functions for UUID58 strings without requiring
full decoding. The new `isUuid58()` function provides a fast way to check if a
string is a valid UUID58-encodable value.

## Changes

### New Features

- **`isUuid58(uuid58: string): boolean`** - Validates whether a string is a valid
  UUID58 string
  - Checks length (must be exactly 22 characters)
  - Validates Base58 alphabet characters
  - Ensures the decoded value fits within 128 bits (UUID size)
  - Optimized to avoid full decoding for better performance

### Implementation Details

The `isUuid58()` function uses an efficient comparison algorithm:

- Validates character codes against the Base58 alphabet
- Compares against the maximum UUID value encoded in Base58
  (`YcVfxkQb6JRzqk5kF2tNLv`) using ASCII order
- Returns early on invalid characters or values exceeding 128 bits

### Testing

- Comprehensive test suite covering:
  - Boundary values (minimum and maximum UUID values)
  - Valid UUID58 strings
  - Invalid length cases
  - Invalid character cases
  - Values exceeding 128 bits
  - Consistency with decode function behavior

### Exports

The new function is exported from the main `index.ts` entry point for easy
access.

## Benefits

- **Performance**: Validation without full decoding is faster for simple checks
- **Convenience**: Simple boolean return value for easy use in conditionals
- **Type Safety**: Full TypeScript support with comprehensive JSDoc
  documentation
