### PR TITLE
feat: simplify release strategy

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,9 @@
 name: Publish
+
 on:
-  push:
-    branches:
-      - main
+  pull_request:
+    types: [closed]
+    branches: [main]
 
 permissions:
   contents: write
@@ -11,6 +12,9 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    if: |
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.head.ref == 'release'
     environment: production
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI trigger/gating change only; main risk is accidentally not publishing (or publishing unexpectedly) due to branch/merge condition mismatches.
> 
> **Overview**
> Updates the `Publish` GitHub Actions workflow to run on *merged* `pull_request` events to `main`, instead of `push` to `main`.
> 
> The publish job is now gated to only execute when the merged PR’s source branch is `release`, tightening when production publishing and release creation can occur.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 788c4b830ff0dc373bc7d92e551db7c02a6c6c89. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->